### PR TITLE
FIX en la generación del XML y pasando la cadena original a utf8

### DIFF
--- a/lib/CFDI.js
+++ b/lib/CFDI.js
@@ -16,34 +16,36 @@ class CFDI extends Node{
     return this._makeXml()
   }
 
-  /**
-   *
-   * @returns {*}
-   * @private
-   */
-  _makeXml (internal = false) {
-    this.makeAllNodes()
-    this.nodes.forEach(node => {
-      node.makeAllNodes()
-    })
+	/**
+	 *
+	 * @returns {*}
+	 * @private
+	 */
+	async _makeXml () {
+		this.makeAllNodes()
+		this.nodes.forEach(node => {
+			node.makeAllNodes()
+		})
 
-    const Cfdi = JXON.unbuild(this.getAttributes(), null, this.nodeName);
-    let xmlString =  JXON.xmlToString(Cfdi)
-    xmlString = xmlString.replace(' xmlns:cfdi=""', '')
-    let xmlObject = JXON.stringToXml(xmlString)
-    let jsObject = JXON.xmlToJs(xmlObject)
-
-    if (!this.withOutCerts && !internal) {
-      return this.getCadenaOriginal()
-	  .then(cadenaOriginal => this.getSello(cadenaOriginal))
-	  .then(sello => {
-	    jsObject['cfdi:Comprobante']['$Sello'] = sello
-		xmlObject = JXON.jsToXml(jsObject)
-		xmlString = JXON.xmlToString(xmlObject);
-		xmlString = `<?xml version="1.0" encoding="UTF-8"?>${xmlString}`
-		return xmlString
-	  })
-    }
+		const Cfdi = JXON.unbuild(this.getAttributes(), null, this.nodeName);
+		let xmlString =  JXON.xmlToString(Cfdi)
+		xmlString = xmlString.replace(' xmlns:cfdi=""', '')
+		let xmlObject = JXON.stringToXml(xmlString)
+		let jsObject = JXON.xmlToJs(xmlObject)
+		
+		if (!this.withOutCerts) {
+			xmlObject = JXON.jsToXml(jsObject)
+			xmlString = JXON.xmlToString(xmlObject);
+			xmlString = `<?xml version="1.0" encoding="UTF-8"?>${xmlString}`
+			let cadenaOriginal = await this.getCadenaOriginal(xmlString)
+			let sello = await this.getSello(cadenaOriginal)
+			jsObject['cfdi:Comprobante']['$Sello'] = sello
+			xmlObject = JXON.jsToXml(jsObject)
+			xmlString = JXON.xmlToString(xmlObject);
+			xmlString = `<?xml version="1.0" encoding="UTF-8"?>${xmlString}`
+			return xmlString
+		}
+	}
 
 	xmlObject = JXON.jsToXml(jsObject)
 	xmlString = JXON.xmlToString(xmlObject);
@@ -59,6 +61,8 @@ class CFDI extends Node{
   getDefaultAttributes () {
     let attr = {
       '$xmlns:cfdi': 'http://www.sat.gob.mx/cfd/3',
+			'$xmlns:xsi':'http://www.w3.org/2001/XMLSchema-instance',
+			'$xsi:schemaLocation' : 'http://www.sat.gob.mx/cfd/3 http://www.sat.gob.mx/sitio_internet/cfd/3/cfdv33.xsd',      
       '$Version': CFDI.version
     }
 
@@ -115,7 +119,7 @@ class CFDI extends Node{
 		const pem = fs.readFileSync(this.key)
 		const key = pem.toString('ascii')
 		const sign = crypto.createSign('RSA-SHA256')
-		sign.update(cadenaOriginal)
+		sign.update(cadenaOriginal.toString('utf8'))
 
 		return resolve(sign.sign(key, 'base64'))
 	  } catch (err) {


### PR DESCRIPTION
Hola!

La librería me generaba mal el XML que era enviado al método para la generación del sellado de la cadena original. Según vi, era porque como llamaba 2 veces a la función makeXML y en ambos buscaba generar los nodos del XML, la segunda vez, quedaban datos en memoria y pues repetía la información.